### PR TITLE
stop timer on view removal

### DIFF
--- a/Pod/Classes/LiquidLoadEffect.swift
+++ b/Pod/Classes/LiquidLoadEffect.swift
@@ -19,7 +19,7 @@ class LiquidLoadEffect : NSObject {
     var moveCircle: LiquittableCircle?
     var shadowCircle: LiquittableCircle?
     
-    var timer: NSTimer?
+    var timer:  CADisplayLink?
 
     weak var loader: LiquidLoader!
     
@@ -65,7 +65,8 @@ class LiquidLoadEffect : NSObject {
         }
         resize()
 
-        timer = NSTimer.scheduledTimerWithTimeInterval(0.02, target: self, selector: Selector("update"), userInfo: nil, repeats: true)
+        timer = CADisplayLink(target: self, selector: "update")
+        timer?.addToRunLoop(NSRunLoop.mainRunLoop(), forMode: NSRunLoopCommonModes)
     }
     
     func updateKeyframe(key: CGFloat) {

--- a/Pod/Classes/LiquidLoadEffect.swift
+++ b/Pod/Classes/LiquidLoadEffect.swift
@@ -18,6 +18,8 @@ class LiquidLoadEffect : NSObject {
     var engine: SimpleCircleLiquidEngine?
     var moveCircle: LiquittableCircle?
     var shadowCircle: LiquittableCircle?
+    
+    var timer: NSTimer?
 
     weak var loader: LiquidLoader!
     
@@ -63,7 +65,7 @@ class LiquidLoadEffect : NSObject {
         }
         resize()
 
-        var timer = NSTimer.scheduledTimerWithTimeInterval(0.02, target: self, selector: Selector("update"), userInfo: nil, repeats: true)
+        timer = NSTimer.scheduledTimerWithTimeInterval(0.02, target: self, selector: Selector("update"), userInfo: nil, repeats: true)
     }
     
     func updateKeyframe(key: CGFloat) {
@@ -116,4 +118,7 @@ class LiquidLoadEffect : NSObject {
         }
     }
 
+    func stopTimer() {
+        timer?.invalidate()
+    }
 }

--- a/Pod/Classes/LiquidLoader.swift
+++ b/Pod/Classes/LiquidLoader.swift
@@ -56,4 +56,12 @@ public class LiquidLoader : UIView {
     public func hide() {
         self.hidden = true
     }
+    
+    override public func didMoveToWindow() {
+        super.didMoveToWindow()
+        if(self.window == nil) {
+            // we were removed.. lets stop everything
+            effectDelegate?.stopTimer()
+        }
+    }
 }

--- a/Pod/Classes/SimpleCircleLiquidEngine.swift
+++ b/Pod/Classes/SimpleCircleLiquidEngine.swift
@@ -113,22 +113,18 @@ class SimpleCircleLiquidEngine {
         let (p3, p4) = circleConnectedPoint(other, other: circle, angle: CGMath.degToRad(40))
 
         if let crossed = CGPoint.intersection(p1, to: p3, from2: p2, to2: p4) {
-            let (d1, _d1) = self.circleConnectedPoint(circle, other: other, angle: 0)
-            let (d2, _d2) = self.circleConnectedPoint(other, other: circle, angle: 0)
+            let (d1, _) = self.circleConnectedPoint(circle, other: other, angle: 0)
+            let (d2, _) = self.circleConnectedPoint(other, other: circle, angle: 0)
             let r = (ratio - ConnectThresh) / (angleThresh - ConnectThresh)
 
             let a1 = d1.split(crossed.mid(d2), ratio: 1 - r)
             let part = withBezier { path in
                 path.moveToPoint(p1)
-                let cp1 = a1.split(p1, ratio: ratio)
-                let cp2 = a1.split(p2, ratio: ratio)
                 path.addQuadCurveToPoint(p2, controlPoint: a1)
             }
             let a2 = d2.split(crossed.mid(d1), ratio: 1 - r)
             let part2 = withBezier { path in
                 path.moveToPoint(p3)
-                let cp1 = a2.split(p3, ratio: ratio)
-                let cp2 = a2.split(p4, ratio: ratio)
                 path.addQuadCurveToPoint(p4, controlPoint: a2)
             }
             return [part, part2]


### PR DESCRIPTION
This PR stops the NSTimer if the view is removed, to help prevent cpu being consumed in the background while not visible. It also cleans up some minor Xcode warnings.
